### PR TITLE
Set test filename via ENV

### DIFF
--- a/cmd/todo/main_test.go
+++ b/cmd/todo/main_test.go
@@ -11,10 +11,9 @@ import (
 	"testing"
 )
 
-var (
-	binName  = "todo"
-	fileName = ".todo.json"
-)
+var binName = "todo"
+
+const fileName = ".test_todo.json"
 
 func TestMain(m *testing.M) {
 	fmt.Println("Building tool...")
@@ -29,6 +28,14 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "Cannot build tool %s: %s", binName, err)
 		os.Exit(1)
 	}
+
+	err := os.Setenv("TODO_FILENAME", fileName)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot set TODO_FILENAME: %s", err)
+		os.Exit(1)
+	}
+
 	fmt.Println("Running tests...")
 	result := m.Run()
 


### PR DESCRIPTION
We should avoid using the default filename when testing main.go, so that we don't have an issue if someone was using main.go directly.